### PR TITLE
[#11] feature 채팅 검색 기능 구현

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -216,4 +216,7 @@ gradle-app.setting
 # Java heap dump
 *.hprof
 
+# QueryDsl
+/src/main/generated/**
+
 # End of https://www.toptal.com/developers/gitignore/api/gradle,intellij+all,macos,windows,git,java

--- a/build.gradle
+++ b/build.gradle
@@ -1,3 +1,9 @@
+buildscript {
+    ext {
+        queryDslVersion = "5.0.0"
+    }
+}
+
 plugins {
     id 'java'
     id 'org.springframework.boot' version '3.0.6'
@@ -12,6 +18,12 @@ repositories {
     mavenCentral()
 }
 
+configurations {
+    compileOnly {
+        extendsFrom annotationProcessor
+    }
+}
+
 dependencies {
     implementation 'org.springframework.boot:spring-boot-starter-data-jpa'
     implementation 'org.springframework.boot:spring-boot-starter-validation'
@@ -20,8 +32,31 @@ dependencies {
     runtimeOnly 'com.mysql:mysql-connector-j'
     testImplementation 'org.springframework.boot:spring-boot-starter-test'
     testImplementation 'io.rest-assured:rest-assured'
+
+    // QueryDSL 설정
+    implementation "com.querydsl:querydsl-jpa:${queryDslVersion}:jakarta"
+    implementation "com.querydsl:querydsl-core"
+    implementation "com.querydsl:querydsl-collections"
+
+    annotationProcessor "com.querydsl:querydsl-apt:${dependencyManagement.importedProperties['querydsl.version']}:jakarta"
+    annotationProcessor "jakarta.persistence:jakarta.persistence-api"
+    annotationProcessor "jakarta.annotation:jakarta.annotation-api"
 }
 
 tasks.named('test') {
     useJUnitPlatform()
+}
+
+def generated = 'src/main/generated'
+
+tasks.withType(JavaCompile) {
+    options.getGeneratedSourceOutputDirectory().set(file(generated))
+}
+
+sourceSets {
+    main.java.srcDirs += [generated]
+}
+
+clean {
+    delete file(generated)
 }

--- a/src/main/java/chat/woowa/woowachat/chat/domain/ChatQueryRepository.java
+++ b/src/main/java/chat/woowa/woowachat/chat/domain/ChatQueryRepository.java
@@ -1,0 +1,73 @@
+package chat.woowa.woowachat.chat.domain;
+
+
+import static chat.woowa.woowachat.chat.domain.QChat.chat;
+import static chat.woowa.woowachat.member.domain.QMember.member;
+import static org.springframework.util.StringUtils.hasText;
+
+import chat.woowa.woowachat.common.entity.BaseEntity;
+import chat.woowa.woowachat.member.domain.Course;
+import com.querydsl.core.types.dsl.BooleanExpression;
+import com.querydsl.jpa.impl.JPAQuery;
+import com.querydsl.jpa.impl.JPAQueryFactory;
+import java.util.List;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.support.PageableExecutionUtils;
+import org.springframework.stereotype.Repository;
+
+@Repository
+public class ChatQueryRepository {
+
+    private final JPAQueryFactory query;
+
+    public ChatQueryRepository(final JPAQueryFactory query) {
+        this.query = query;
+    }
+
+    public Page<Chat> search(final ChatSearchCond cond, final Pageable pageable) {
+        final List<Long> longs = nameAndCourseMatchMemberIds(cond);
+        final List<Chat> contents = query.selectFrom(chat)
+                .where(
+                        titleLikeIgnoreCase(cond.title),
+                        chat.memberId.in(longs)
+                ).orderBy(chat.createdAt.desc())
+                .offset(pageable.getOffset())
+                .limit(pageable.getPageSize())
+                .fetch();
+
+        JPAQuery<Long> countQuery = query.select(chat.count()).from(chat);
+
+        return PageableExecutionUtils.getPage(contents, pageable, countQuery::fetchOne);
+    }
+
+    /* 이름과 코스에 해당하는 회원 id 조회 */
+    private List<Long> nameAndCourseMatchMemberIds(final ChatSearchCond cond) {
+        return query.selectFrom(member)
+                .where(
+                        nameLikeIgnoreCase(cond.name),
+                        courseEquals(cond.course)).fetch()
+                .stream()
+                .map(BaseEntity::id)
+                .toList();
+    }
+
+    private BooleanExpression nameLikeIgnoreCase(final String name) {
+        return hasText(name) ? member.name.likeIgnoreCase("%" + name.strip() + "%") : null;
+    }
+
+    private BooleanExpression courseEquals(final Course course) {
+        return (course == null) ? null : member.course.eq(course);
+    }
+
+    private BooleanExpression titleLikeIgnoreCase(final String title) {
+        return hasText(title) ? chat.title.likeIgnoreCase("%" + title.strip() + "%") : null;
+    }
+
+    public record ChatSearchCond(
+            String name,
+            String title,
+            Course course
+    ) {
+    }
+}

--- a/src/main/java/chat/woowa/woowachat/chat/dto/ChatSearchQueryDto.java
+++ b/src/main/java/chat/woowa/woowachat/chat/dto/ChatSearchQueryDto.java
@@ -1,0 +1,14 @@
+package chat.woowa.woowachat.chat.dto;
+
+import chat.woowa.woowachat.member.domain.Course;
+import java.time.LocalDateTime;
+
+public record ChatSearchQueryDto(
+        Long id,
+        Long crewId,
+        String crewName,
+        Course course,
+        String title,
+        LocalDateTime createdAt
+) {
+}

--- a/src/main/java/chat/woowa/woowachat/chat/presentation/ChatController.java
+++ b/src/main/java/chat/woowa/woowachat/chat/presentation/ChatController.java
@@ -4,13 +4,19 @@ import static org.springframework.http.HttpStatus.CREATED;
 
 import chat.woowa.woowachat.chat.application.AskChatService;
 import chat.woowa.woowachat.chat.application.ChatQueryService;
+import chat.woowa.woowachat.chat.domain.ChatQueryRepository.ChatSearchCond;
 import chat.woowa.woowachat.chat.dto.AskCommand;
 import chat.woowa.woowachat.chat.dto.AskRequest;
 import chat.woowa.woowachat.chat.dto.ChatQueryDto;
+import chat.woowa.woowachat.chat.dto.ChatSearchQueryDto;
 import chat.woowa.woowachat.chat.dto.MessageDto;
+import chat.woowa.woowachat.common.presentation.PageResponse;
 import chat.woowa.woowachat.member.presentation.argumentresolver.Auth;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.web.PageableDefault;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.ModelAttribute;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
@@ -56,5 +62,14 @@ public class ChatController {
             @PathVariable final Long id
     ) {
         return ResponseEntity.ok(chatQueryService.findById(id));
+    }
+
+    @GetMapping("/chats")
+    public ResponseEntity<PageResponse<ChatSearchQueryDto>> search(
+            @ModelAttribute final ChatSearchCond cond,
+            @PageableDefault(size = 20) final Pageable pageable
+    ) {
+        return ResponseEntity.ok(
+                PageResponse.from(chatQueryService.search(cond, pageable)));
     }
 }

--- a/src/main/java/chat/woowa/woowachat/common/config/QueryDslConfig.java
+++ b/src/main/java/chat/woowa/woowachat/common/config/QueryDslConfig.java
@@ -1,0 +1,19 @@
+package chat.woowa.woowachat.common.config;
+
+import com.querydsl.jpa.impl.JPAQueryFactory;
+import jakarta.persistence.EntityManager;
+import jakarta.persistence.PersistenceContext;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+@Configuration
+public class QueryDslConfig {
+
+    @PersistenceContext
+    private EntityManager entityManager;
+
+    @Bean
+    public JPAQueryFactory jpaQueryFactory() {
+        return new JPAQueryFactory(entityManager);
+    }
+}

--- a/src/main/java/chat/woowa/woowachat/common/presentation/PageResponse.java
+++ b/src/main/java/chat/woowa/woowachat/common/presentation/PageResponse.java
@@ -1,0 +1,28 @@
+package chat.woowa.woowachat.common.presentation;
+
+import java.util.List;
+import org.springframework.data.domain.Page;
+
+public record PageResponse<T>(
+        List<T> content,
+        boolean last,
+        boolean first,
+        boolean empty,
+        int totalPages,
+        int currentPages,
+        long totalElements,
+        int numberOfElements
+) {
+
+    public static <T> PageResponse<T> from(final Page<T> response) {
+        return new PageResponse<T>(
+                response.getContent(),
+                response.isLast(),
+                response.isFirst(),
+                response.isEmpty(),
+                response.getTotalPages(),
+                response.getNumber(),
+                response.getTotalElements(),
+                response.getNumberOfElements());
+    }
+}

--- a/src/test/java/chat/woowa/woowachat/chat/application/ChatQueryServiceTest.java
+++ b/src/test/java/chat/woowa/woowachat/chat/application/ChatQueryServiceTest.java
@@ -2,15 +2,19 @@ package chat.woowa.woowachat.chat.application;
 
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.api.Assertions.assertAll;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.BDDMockito.given;
 import static org.mockito.Mockito.mock;
 
 import chat.woowa.woowachat.chat.domain.Chat;
+import chat.woowa.woowachat.chat.domain.ChatQueryRepository;
+import chat.woowa.woowachat.chat.domain.ChatQueryRepository.ChatSearchCond;
 import chat.woowa.woowachat.chat.domain.ChatRepository;
 import chat.woowa.woowachat.chat.domain.Message;
 import chat.woowa.woowachat.chat.dto.ChatQueryDto;
 import chat.woowa.woowachat.chat.dto.ChatQueryDto.MessageQueryDto;
+import chat.woowa.woowachat.chat.dto.ChatSearchQueryDto;
 import chat.woowa.woowachat.chat.fixture.ChatFixture;
 import chat.woowa.woowachat.member.domain.Course;
 import chat.woowa.woowachat.member.domain.Member;
@@ -22,6 +26,9 @@ import org.junit.jupiter.api.DisplayNameGeneration;
 import org.junit.jupiter.api.DisplayNameGenerator.ReplaceUnderscores;
 import org.junit.jupiter.api.Test;
 import org.mockito.InjectMocks;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.data.support.PageableExecutionUtils;
 
 @SuppressWarnings("NonAsciiCharacters")
 @DisplayNameGeneration(ReplaceUnderscores.class)
@@ -29,28 +36,65 @@ import org.mockito.InjectMocks;
 class ChatQueryServiceTest {
 
     private final ChatRepository chatRepository = mock(ChatRepository.class);
-
     private final MemberRepository memberRepository = mock(MemberRepository.class);
+    private final ChatQueryRepository chatQueryRepository = mock(ChatQueryRepository.class);
 
     @InjectMocks
-    private ChatQueryService chatQueryService = new ChatQueryService(memberRepository, chatRepository);
+    private ChatQueryService chatQueryService =
+            new ChatQueryService(memberRepository, chatRepository, chatQueryRepository);
 
     @Test
     void 단일_채팅_기록을_전부_조회한다() {
         // given
         final Chat chat = ChatFixture.chatWithMessages(
-                List.of(Message.user("안녕", 1), Message.user("안녕하세요", 1), Message.user("반가워 ", 1),
+                List.of(Message.user("안녕", 1),
+                        Message.user("안녕하세요", 1),
+                        Message.user("반가워 ", 1),
                         Message.user("저도 반갑습니다", 1)));
-        given(chatRepository.findById(1L)).willReturn(Optional.of(chat));
-        given(memberRepository.findById(any())).willReturn(Optional.of(new Member("말랑", Course.BACKEND)));
+        given(chatRepository.findById(1L))
+                .willReturn(Optional.of(chat));
+        given(memberRepository.findById(any()))
+                .willReturn(Optional.of(new Member("말랑", Course.BACKEND)));
 
         // when
         final ChatQueryDto chatQueryDto = chatQueryService.findById(1L);
 
         // then
-        assertThat(chatQueryDto.crewName()).isEqualTo("말랑");
-        assertThat(chatQueryDto.title()).isEqualTo("안녕");
-        assertThat(chatQueryDto.messages()).extracting(MessageQueryDto::content)
-                .containsExactly("안녕", "안녕하세요", "반가워 ", "저도 반갑습니다");
+        assertAll(
+                () -> assertThat(chatQueryDto.crewName()).isEqualTo("말랑"),
+                () -> assertThat(chatQueryDto.title()).isEqualTo("안녕"),
+                () -> assertThat(chatQueryDto.messages())
+                        .extracting(MessageQueryDto::content)
+                        .containsExactly("안녕", "안녕하세요", "반가워 ", "저도 반갑습니다")
+        );
+    }
+
+    @Test
+    void 검색할_수_있다() {
+        // given
+        final Chat chat1 = ChatFixture.chatWithMessages(List.of(Message.user("제목1", 1)));
+        final Chat chat2 = ChatFixture.chatWithMessages(List.of(Message.user("제목2", 1)));
+        final Page<Chat> page = PageableExecutionUtils.getPage(
+                List.of(chat1, chat2),
+                PageRequest.of(0, 10),
+                () -> 0);
+        given(chatQueryRepository.search(any(), any()))
+                .willReturn(page);
+        given(memberRepository.findById(any()))
+                .willReturn(Optional.of(new Member("말랑", Course.BACKEND)));
+
+        // when
+        final Page<ChatSearchQueryDto> search = chatQueryService.search(
+                new ChatSearchCond(null, null, null),
+                PageRequest.of(1, 1)
+        );
+
+        // then
+        final ChatSearchQueryDto chatSearchQueryDto = search.getContent().get(0);
+        assertAll(
+                () -> assertThat(chatSearchQueryDto.crewName()).isEqualTo("말랑"),
+                () -> assertThat(chatSearchQueryDto.course()).isEqualTo(Course.BACKEND),
+                () -> assertThat(chatSearchQueryDto.title()).isEqualTo("제목1")
+        );
     }
 }

--- a/src/test/java/chat/woowa/woowachat/chat/domain/ChatQueryRepositoryTest.java
+++ b/src/test/java/chat/woowa/woowachat/chat/domain/ChatQueryRepositoryTest.java
@@ -28,8 +28,8 @@ import org.springframework.data.domain.PageRequest;
 @SuppressWarnings("NonAsciiCharacters")
 @DisplayNameGeneration(ReplaceUnderscores.class)
 @DisplayName("ChatQueryRepository 은(는)")
-@DataJpaTest
 @Import({QueryDslConfig.class, ChatQueryRepository.class, JpaConfig.class})
+@DataJpaTest
 class ChatQueryRepositoryTest {
 
     @Autowired
@@ -51,7 +51,6 @@ class ChatQueryRepositoryTest {
         saveMemberChat(memberRepository.save(new Member("백엔드허브", BACKEND)));
         saveMemberChat(memberRepository.save(new Member("백엔드말랑", BACKEND)));
         flushAndClear();
-        System.out.println("============================");
     }
 
     private void saveMemberChat(final Member member) {

--- a/src/test/java/chat/woowa/woowachat/chat/domain/ChatQueryRepositoryTest.java
+++ b/src/test/java/chat/woowa/woowachat/chat/domain/ChatQueryRepositoryTest.java
@@ -1,0 +1,141 @@
+package chat.woowa.woowachat.chat.domain;
+
+import static chat.woowa.woowachat.chat.domain.GptModel.GPT_3_5_TURBO;
+import static chat.woowa.woowachat.member.domain.Course.ANDROID;
+import static chat.woowa.woowachat.member.domain.Course.BACKEND;
+import static chat.woowa.woowachat.member.domain.Course.FRONTEND;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.api.Assertions.assertAll;
+
+import chat.woowa.woowachat.chat.domain.ChatQueryRepository.ChatSearchCond;
+import chat.woowa.woowachat.common.config.QueryDslConfig;
+import chat.woowa.woowachat.member.domain.Member;
+import chat.woowa.woowachat.member.domain.MemberRepository;
+import jakarta.persistence.EntityManager;
+import java.util.List;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.DisplayNameGeneration;
+import org.junit.jupiter.api.DisplayNameGenerator.ReplaceUnderscores;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest;
+import org.springframework.context.annotation.Import;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageRequest;
+
+@SuppressWarnings("NonAsciiCharacters")
+@DisplayNameGeneration(ReplaceUnderscores.class)
+@DisplayName("ChatQueryRepository 은(는)")
+@DataJpaTest
+@Import({QueryDslConfig.class, ChatQueryRepository.class})
+class ChatQueryRepositoryTest {
+
+    @Autowired
+    private EntityManager em;
+    @Autowired
+    private MemberRepository memberRepository;
+    @Autowired
+    private ChatQueryRepository chatQueryRepository;
+    @Autowired
+    private ChatRepository chatRepository;
+
+
+    @BeforeEach
+    void setUp() {
+        saveMemberChat(memberRepository.save(new Member("프론트엔드허브", FRONTEND)));
+        saveMemberChat(memberRepository.save(new Member("프론트엔드말랑", FRONTEND)));
+        saveMemberChat(memberRepository.save(new Member("안드로이드허브", ANDROID)));
+        saveMemberChat(memberRepository.save(new Member("안드로이드말랑", ANDROID)));
+        saveMemberChat(memberRepository.save(new Member("백엔드허브", BACKEND)));
+        saveMemberChat(memberRepository.save(new Member("백엔드말랑", BACKEND)));
+        saveAndFlush();
+        System.out.println("============================");
+    }
+
+    private void saveMemberChat(final Member member) {
+        final Chat chat = new Chat(GPT_3_5_TURBO, SettingMessage.byCourse(member.course()), member.name() + "의 Title",
+                member.id(), Message.user(member.name() + "의 Title", 2));
+        chat.addMessage(Message.assistant("안녕하세요", 5));
+        chatRepository.save(chat);
+    }
+
+    @Test
+    void 검색_조건이_설정되지_않으면_페이징하며_전체_조회() {
+        // when
+        final Page<Chat> search = chatQueryRepository.search(new ChatSearchCond(null, null, null),
+                PageRequest.of(0, 20));
+
+        // then
+        final List<Chat> content = search.getContent();
+        assertAll(() -> assertThat(content).hasSize(6),
+                () -> assertThat(content.get(0).messages()).extracting(Message::content)
+                        .containsExactly("프론트엔드허브의 Title", "안녕하세요"),
+                () -> assertThat(content.get(1).messages()).extracting(Message::content)
+                        .containsExactly("프론트엔드말랑의 Title", "안녕하세요"));
+    }
+
+    @Test
+    void 이름으로_검색_가능() {
+        // when
+        final Page<Chat> search = chatQueryRepository.search(new ChatSearchCond("말", null, null),
+                PageRequest.of(0, 20));
+
+        // then
+        final List<Chat> content = search.getContent();
+        assertAll(() -> assertThat(content).hasSize(3),
+                () -> assertThat(content.get(0).messages()).extracting(Message::content)
+                        .containsExactly("프론트엔드말랑의 Title", "안녕하세요"),
+                () -> assertThat(content.get(1).messages()).extracting(Message::content)
+                        .containsExactly("안드로이드말랑의 Title", "안녕하세요"),
+                () -> assertThat(content.get(2).messages()).extracting(Message::content)
+                        .containsExactly("백엔드말랑의 Title", "안녕하세요"));
+    }
+
+    @Test
+    void 제목으로_검색_가능() {
+        // when
+        final Page<Chat> search = chatQueryRepository.search(new ChatSearchCond(null, " 엔드허브의 tiTlE    ", null),
+                PageRequest.of(0, 20));
+
+        // then
+        final List<Chat> content = search.getContent();
+        assertAll(() -> assertThat(content).hasSize(2),
+                () -> assertThat(content.get(0).messages()).extracting(Message::content)
+                        .containsExactly("프론트엔드허브의 Title", "안녕하세요"),
+                () -> assertThat(content.get(1).messages()).extracting(Message::content)
+                        .containsExactly("백엔드허브의 Title", "안녕하세요"));
+    }
+
+
+    @Test
+    void 과정으로_검색_가능() {
+        // when
+        final Page<Chat> search = chatQueryRepository.search(new ChatSearchCond(null, null, ANDROID),
+                PageRequest.of(0, 20));
+
+        // then
+        final List<Chat> content = search.getContent();
+        assertAll(() -> assertThat(content).hasSize(2),
+                () -> assertThat(content.get(0).messages()).extracting(Message::content)
+                        .containsExactly("안드로이드허브의 Title", "안녕하세요"),
+                () -> assertThat(content.get(1).messages()).extracting(Message::content)
+                        .containsExactly("안드로이드말랑의 Title", "안녕하세요"));
+    }
+
+    @Test
+    void 이름_제목_과정으로_검색_가능() {
+        // when
+        final Page<Chat> search = chatQueryRepository.search(new ChatSearchCond("말랑", "허브", BACKEND),
+                PageRequest.of(0, 20));
+
+        // then
+        final List<Chat> content = search.getContent();
+        assertThat(content).hasSize(0);
+    }
+
+    private void saveAndFlush() {
+        em.flush();
+        em.clear();
+    }
+}

--- a/src/test/java/chat/woowa/woowachat/chat/presentation/ChatControllerTest.java
+++ b/src/test/java/chat/woowa/woowachat/chat/presentation/ChatControllerTest.java
@@ -151,6 +151,7 @@ class ChatControllerTest {
 
         // when & then
         RestAssured.given()
+                .log().all()
                 .when()
                 .get("/chats?name=허브&course=FRONTEND")
                 .then()

--- a/src/test/java/chat/woowa/woowachat/chat/presentation/ChatControllerTest.java
+++ b/src/test/java/chat/woowa/woowachat/chat/presentation/ChatControllerTest.java
@@ -2,6 +2,7 @@ package chat.woowa.woowachat.chat.presentation;
 
 import static org.hamcrest.Matchers.equalTo;
 import static org.hamcrest.Matchers.notNullValue;
+import static org.junit.jupiter.api.Assertions.assertAll;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.BDDMockito.given;
 import static org.springframework.http.HttpStatus.CREATED;
@@ -17,6 +18,7 @@ import chat.woowa.woowachat.member.domain.MemberRepository;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import io.restassured.RestAssured;
 import io.restassured.http.Header;
+import io.restassured.response.ValidatableResponse;
 import java.util.Base64;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
@@ -49,6 +51,18 @@ class ChatControllerTest {
 
     @MockBean
     private GptClient gptClient;
+
+    private static void validateMessage(final ValidatableResponse validatableResponse,
+                                        final int index,
+                                        final int id,
+                                        final String content,
+                                        final String role) {
+        validatableResponse
+                .body("messages[" + index + "].id", equalTo(id))
+                .body("messages[" + index + "].content", equalTo(content))
+                .body("messages[" + index + "].role", equalTo(role))
+                .body("messages[" + index + "].createdAt", notNullValue());
+    }
 
     @BeforeEach
     void setUp() {
@@ -105,37 +119,63 @@ class ChatControllerTest {
         질문을_이어서_한다();
 
         // when
-        RestAssured.given().log().all()
+        final ValidatableResponse validatableResponse = RestAssured.given()
+                .log().all()
                 .when()
                 .get("/chats/" + 1L)
                 .then()
                 .log().all()
-                .statusCode(OK.value())
+                .statusCode(OK.value());
+
+        // then
+        validatableResponse
                 .body("id", equalTo(1))
                 .body("crewName", equalTo("말랑"))
                 .body("course", equalTo("BACKEND"))
                 .body("title", equalTo("안녕?"))
-                .body("createdAt", notNullValue())
+                .body("createdAt", notNullValue());
+        assertAll(
+                () -> validateMessage(validatableResponse, 0, 1, "안녕?", "user"),
+                () -> validateMessage(validatableResponse, 1, 2, "응 안녕", "assistant"),
+                () -> validateMessage(validatableResponse, 2, 3, "안녕? 두번째", "user"),
+                () -> validateMessage(validatableResponse, 3, 4, "응 안녕 두번째", "assistant")
+        );
+    }
 
-                .body("messages[0].id", equalTo(1))
-                .body("messages[0].content", equalTo("안녕?"))
-                .body("messages[0].role", equalTo("user"))
-                .body("messages[0].createdAt", notNullValue())
+    @Test
+    void 이름_과정_제목으로_검색한다() throws Exception {
+        // given
+        질문을_한다("안드로이드 허브", Course.ANDROID);
+        질문을_한다("프론트 허브", Course.FRONTEND);
+        질문을_한다("프론트2 허브", Course.FRONTEND);
 
-                .body("messages[1].id", equalTo(2))
-                .body("messages[1].content", equalTo("응 안녕"))
-                .body("messages[1].role", equalTo("assistant"))
-                .body("messages[1].createdAt", notNullValue())
+        // when & then
+        RestAssured.given()
+                .when()
+                .get("/chats?name=허브&course=FRONTEND")
+                .then()
+                .body("content[0].crewName", equalTo("프론트2 허브"))
+                .body("content[0].course", equalTo("FRONTEND"))
+                .body("content[1].crewName", equalTo("프론트 허브"))
+                .body("content[1].course", equalTo("FRONTEND"))
+                .body("totalElements", equalTo(2))
+                .log().all();
+    }
 
-                .body("messages[2].id", equalTo(3))
-                .body("messages[2].content", equalTo("안녕? 두번째"))
-                .body("messages[2].role", equalTo("user"))
-                .body("messages[2].createdAt", notNullValue())
+    private void 질문을_한다(final String name, final Course course) throws Exception {
+        memberRepository.save(new Member(name, course)).id();
+        given(gptClient.ask(any()))
+                .willReturn(Message.assistant("응 안녕", 10));
+        final AskRequest askRequest = new AskRequest("안녕?", 50);
+        final String body = objectMapper.writeValueAsString(askRequest);
 
-                .body("messages[3].id", equalTo(4))
-                .body("messages[3].content", equalTo("응 안녕 두번째"))
-                .body("messages[3].role", equalTo("assistant"))
-                .body("messages[3].createdAt", notNullValue());
+        // when & then
+        RestAssured.given()
+                .header(new Header("name", encode(name)))
+                .contentType(APPLICATION_JSON_VALUE)
+                .body(body)
+                .when()
+                .post("/chats");
     }
 
     private String encode(final String name) {

--- a/src/test/java/chat/woowa/woowachat/member/domain/MemberRepositoryTest.java
+++ b/src/test/java/chat/woowa/woowachat/member/domain/MemberRepositoryTest.java
@@ -1,12 +1,10 @@
-package chat.woowa.woowachat.member;
+package chat.woowa.woowachat.member.domain;
 
 import static chat.woowa.woowachat.member.domain.Course.BACKEND;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.jupiter.api.Assertions.assertAll;
 
 import chat.woowa.woowachat.common.annotation.JpaRepositoryTest;
-import chat.woowa.woowachat.member.domain.Member;
-import chat.woowa.woowachat.member.domain.MemberRepository;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.DisplayNameGeneration;
 import org.junit.jupiter.api.DisplayNameGenerator;

--- a/src/test/resources/application.yml
+++ b/src/test/resources/application.yml
@@ -1,6 +1,31 @@
 spring:
   datasource:
+    driver-class-name: org.h2.Driver
     url: jdbc:h2:mem:testdb;MODE=MySQL
+    username: sa
+    password:
+
+  h2:
+    console:
+      enabled: true
+      path: /h2-console
+
+  jpa:
+    show_sql: true
+    open-in-view: false
+    properties:
+      hibernate:
+        format_sql: true
+        use_sql_comments: true
+        highlight_sql: true
+        default_batch_fetch_size: 100
+    hibernate:
+      ddl-auto: create
+
+
+logging:
+  level:
+    org.hibernate.orm.jdbc.bind: trace
 
 gpt:
   key: 따로 설정해서 쓰세용


### PR DESCRIPTION
## 구현한 기능
- 크루의 이름 & 채팅의 제목 & 과정(코스)를 조합하여 검색할 수 있도록 구현

<br>

## 검색 요청
```text
Request method:	GET
Request URI:	chats?name={name}&course={course}&title={title}&page={page, 0부터 시작}
```


## 반환 데이터
```json
{
    "content": [
        {
            "id": 3,
            "crewId": 4,
            "crewName": "프론트2 허브",
            "course": "FRONTEND",
            "title": "안녕?",
            "createdAt": "2023-04-27T16:32:14.462562"
        },
        {
            "id": 2,
            "crewId": 3,
            "crewName": "프론트 허브",
            "course": "FRONTEND",
            "title": "안녕?",
            "createdAt": "2023-04-27T16:32:14.453707"
        }
    ],
    "last": true,
    "first": true,
    "empty": false,
    "totalPages": 1,
    "currentPages": 0,
    "totalElements": 2,
    "numberOfElements": 2
}
```

close #11