### PR TITLE
[#36] refactor GPT API 호출을 트랜잭션 범위에서 제외

### DIFF
--- a/src/main/java/chat/woowa/woowachat/chat/application/AskChatService.java
+++ b/src/main/java/chat/woowa/woowachat/chat/application/AskChatService.java
@@ -12,57 +12,61 @@ import chat.woowa.woowachat.chat.dto.MessageDto;
 import chat.woowa.woowachat.member.domain.Member;
 import chat.woowa.woowachat.member.domain.MemberRepository;
 import org.springframework.stereotype.Service;
-import org.springframework.transaction.annotation.Transactional;
+import org.springframework.transaction.support.TransactionTemplate;
 
-@Transactional
 @Service
 public class AskChatService {
 
     private final MemberRepository memberRepository;
     private final ChatRepository chatRepository;
     private final GptClient gptClient;
+    private final TransactionTemplate transactionTemplate;
 
-    public AskChatService(final MemberRepository memberRepository,
-                          final ChatRepository chatRepository,
-                          final GptClient gptClient) {
+    public AskChatService(final MemberRepository memberRepository, final ChatRepository chatRepository,
+                          final GptClient gptClient, final TransactionTemplate transactionTemplate) {
         this.memberRepository = memberRepository;
         this.chatRepository = chatRepository;
         this.gptClient = gptClient;
+        this.transactionTemplate = transactionTemplate;
     }
 
     public MessageDto createAsk(final AskCommand command) {
         final Question question = command.question();
-        final Chat chat = saveInitialChat(command, question);
-        return answer(chat, question);
-    }
-
-    private Chat saveInitialChat(final AskCommand command, final Question question) {
         final Member member = findMemberById(command.memberId());
         Chat chat = new Chat(GptModel.GPT_3_5_TURBO,
                 SettingMessage.byCourse(member.course()),
                 question.content(),
                 command.memberId()
         );
-        return chatRepository.save(chat);
+
+        final QuestionAndAnswer qna = gptClient.ask(chat, question);
+
+        return transactionTemplate.execute(status -> {
+            chatRepository.save(chat);
+            chat.addQuestionAndAnswer(qna);
+            return new MessageDto(chat.id(), qna.answer().content());
+        });
     }
 
     public MessageDto ask(final Long id, final AskCommand command) {
-        final Chat chat = chatRepository.findById(id)
-                .orElseThrow(() -> new IllegalArgumentException("아이디가 %d인 채팅이 없습니다."));
-        return answer(chat, command.question());
+        final Chat chat = findChatWithQuestionAndAnswersById(id);
+
+        final QuestionAndAnswer qna = gptClient.ask(chat, command.question());
+
+        return transactionTemplate.execute(status -> {
+            findChatWithQuestionAndAnswersById(id).addQuestionAndAnswer(qna);
+            return new MessageDto(chat.id(), qna.answer().content());
+        });
     }
 
     private Member findMemberById(final Long memberId) {
-        // TODO 예외처리 변경
         return memberRepository.findById(memberId)
                 .orElseThrow(() ->
-                        new IllegalArgumentException("일치하는 회원 ID가 없습니다. (TODO: 변경)")
-                );
+                        new IllegalArgumentException("일치하는 회원 ID가 없습니다. (TODO: 변경)"));
     }
 
-    private MessageDto answer(final Chat chat, final Question question) {
-        final QuestionAndAnswer ask = gptClient.ask(chat, question);
-        chat.addQuestionAndAnswer(ask);
-        return new MessageDto(chat.id(), ask.answer().content());
+    private Chat findChatWithQuestionAndAnswersById(final Long id) {
+        return chatRepository.findWithQuestionAndAnswersById(id)
+                .orElseThrow(() -> new IllegalArgumentException("아이디가 %d인 채팅이 없습니다."));
     }
 }

--- a/src/main/java/chat/woowa/woowachat/chat/domain/Chat.java
+++ b/src/main/java/chat/woowa/woowachat/chat/domain/Chat.java
@@ -32,6 +32,9 @@ public class Chat extends BaseEntity {
     @Embedded
     private QuestionAndAnswers questionAndAnswers = new QuestionAndAnswers();
 
+    protected Chat() {
+    }
+
     public Chat(final GptModel model,
                 final SettingMessage settingMessage,
                 final String title,
@@ -40,9 +43,6 @@ public class Chat extends BaseEntity {
         this.settingMessage = settingMessage;
         this.title = title;
         this.memberId = memberId;
-    }
-
-    protected Chat() {
     }
 
     public void addQuestionAndAnswer(final QuestionAndAnswer questionAndAnswer) {
@@ -59,28 +59,8 @@ public class Chat extends BaseEntity {
     /**
      * [모델의 최대 토큰 - FREE_TOKEN(2000)] 반환
      */
-    public List<Message> messagesWithFreeToken() {
-        final List<Message> result = new ArrayList<>();
-        result.add(settingMessage);
-        final List<QuestionAndAnswer> lessOrEqualThan =
-                questionAndAnswers.lessOrEqualThan(model.maxTokens() - FREE_TOKEN)
-                        .questionAndAnswers();
-        for (final QuestionAndAnswer qna : lessOrEqualThan) {
-            result.add(qna.question());
-            result.add(qna.answer());
-        }
-        return result;
-    }
-
-    /**
-     * [모델의 최대 토큰 - FREE_TOKEN(2000)] 반환
-     */
     public QuestionAndAnswers qnaWithFreeToken() {
         return questionAndAnswers.lessOrEqualThan(model.maxTokens() - FREE_TOKEN);
-    }
-
-    public int totalToken() {
-        return questionAndAnswers.calculateTokenSum();
     }
 
     public String modelName() {

--- a/src/main/java/chat/woowa/woowachat/chat/domain/Chat.java
+++ b/src/main/java/chat/woowa/woowachat/chat/domain/Chat.java
@@ -63,12 +63,20 @@ public class Chat extends BaseEntity {
         final List<Message> result = new ArrayList<>();
         result.add(settingMessage);
         final List<QuestionAndAnswer> lessOrEqualThan =
-                questionAndAnswers.lessOrEqualThan(model.maxTokens() - FREE_TOKEN);
+                questionAndAnswers.lessOrEqualThan(model.maxTokens() - FREE_TOKEN)
+                        .questionAndAnswers();
         for (final QuestionAndAnswer qna : lessOrEqualThan) {
             result.add(qna.question());
             result.add(qna.answer());
         }
         return result;
+    }
+
+    /**
+     * [모델의 최대 토큰 - FREE_TOKEN(2000)] 반환
+     */
+    public QuestionAndAnswers qnaWithFreeToken() {
+        return questionAndAnswers.lessOrEqualThan(model.maxTokens() - FREE_TOKEN);
     }
 
     public int totalToken() {

--- a/src/main/java/chat/woowa/woowachat/chat/domain/Chat.java
+++ b/src/main/java/chat/woowa/woowachat/chat/domain/Chat.java
@@ -72,10 +72,7 @@ public class Chat extends BaseEntity {
     }
 
     public int totalToken() {
-        return questionAndAnswers.questionAndAnswers()
-                .stream()
-                .mapToInt(QuestionAndAnswer::token)
-                .sum();
+        return questionAndAnswers.calculateTokenSum();
     }
 
     public String modelName() {

--- a/src/main/java/chat/woowa/woowachat/chat/domain/ChatRepository.java
+++ b/src/main/java/chat/woowa/woowachat/chat/domain/ChatRepository.java
@@ -2,9 +2,15 @@ package chat.woowa.woowachat.chat.domain;
 
 
 import java.util.List;
+import java.util.Optional;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 
 public interface ChatRepository extends JpaRepository<Chat, Long> {
 
     List<Chat> findAllByMemberId(final Long memberId);
+
+    @Query("select c from Chat c join fetch c.questionAndAnswers.questionAndAnswers qnas where c.id = :id")
+    Optional<Chat> findWithQuestionAndAnswersById(@Param("id") final Long id);
 }

--- a/src/main/java/chat/woowa/woowachat/chat/domain/QuestionAndAnswers.java
+++ b/src/main/java/chat/woowa/woowachat/chat/domain/QuestionAndAnswers.java
@@ -34,7 +34,7 @@ public class QuestionAndAnswers {
         questionAndAnswers.add(questionAndAnswer);
     }
 
-    public List<QuestionAndAnswer> lessOrEqualThan(final int token) {
+    public QuestionAndAnswers lessOrEqualThan(final int token) {
         final Deque<QuestionAndAnswer> result = new ArrayDeque<>(this.questionAndAnswers);
         int tokenSum = calculateTokenSum();
 
@@ -43,7 +43,7 @@ public class QuestionAndAnswers {
             tokenSum -= message.token();
         }
 
-        return new ArrayList<>(result);
+        return new QuestionAndAnswers(new ArrayList<>(result));
     }
 
     public int calculateTokenSum() {

--- a/src/main/java/chat/woowa/woowachat/chat/domain/QuestionAndAnswers.java
+++ b/src/main/java/chat/woowa/woowachat/chat/domain/QuestionAndAnswers.java
@@ -46,6 +46,16 @@ public class QuestionAndAnswers {
         return new QuestionAndAnswers(new ArrayList<>(result));
     }
 
+    public List<Message> messagesWithSettingMessage(final SettingMessage settingMessage) {
+        final List<Message> result = new ArrayList<>();
+        result.add(settingMessage);
+        for (final QuestionAndAnswer qna : questionAndAnswers) {
+            result.add(qna.question());
+            result.add(qna.answer());
+        }
+        return result;
+    }
+
     public int calculateTokenSum() {
         return questionAndAnswers.stream()
                 .mapToInt(QuestionAndAnswer::token)

--- a/src/main/java/chat/woowa/woowachat/chat/domain/QuestionAndAnswers.java
+++ b/src/main/java/chat/woowa/woowachat/chat/domain/QuestionAndAnswers.java
@@ -46,7 +46,7 @@ public class QuestionAndAnswers {
         return new ArrayList<>(result);
     }
 
-    private int calculateTokenSum() {
+    public int calculateTokenSum() {
         return questionAndAnswers.stream()
                 .mapToInt(QuestionAndAnswer::token)
                 .sum();

--- a/src/test/java/chat/woowa/woowachat/chat/application/ChatQueryServiceTest.java
+++ b/src/test/java/chat/woowa/woowachat/chat/application/ChatQueryServiceTest.java
@@ -19,7 +19,7 @@ import chat.woowa.woowachat.chat.domain.QuestionAndAnswer;
 import chat.woowa.woowachat.chat.dto.ChatQueryDto;
 import chat.woowa.woowachat.chat.dto.ChatQueryDto.MessageQueryDto;
 import chat.woowa.woowachat.chat.dto.ChatSearchQueryDto;
-import chat.woowa.woowachat.chat.fixture.Chat2Fixture;
+import chat.woowa.woowachat.chat.fixture.ChatFixture;
 import chat.woowa.woowachat.member.domain.Course;
 import chat.woowa.woowachat.member.domain.Member;
 import chat.woowa.woowachat.member.domain.MemberRepository;
@@ -50,7 +50,7 @@ class ChatQueryServiceTest {
     @Test
     void 단일_채팅_기록을_전부_조회한다() {
         // given
-        final Chat chat = Chat2Fixture.chat(
+        final Chat chat = ChatFixture.chat(
                 new QuestionAndAnswer(
                         question("안녕"),
                         answer("안녕하세요"),
@@ -82,14 +82,14 @@ class ChatQueryServiceTest {
     @Test
     void 검색할_수_있다() {
         // given
-        final Chat chat1 = Chat2Fixture.chat(
+        final Chat chat1 = ChatFixture.chat(
                 new QuestionAndAnswer(
                         question("안녕"),
                         answer("안녕하세요"),
                         2
                 ));
 
-        final Chat chat = Chat2Fixture.chat(
+        final Chat chat = ChatFixture.chat(
                 new QuestionAndAnswer(
                         question("안녕2"),
                         answer("안녕하세요2"),

--- a/src/test/java/chat/woowa/woowachat/chat/domain/ChatRepositoryTest.java
+++ b/src/test/java/chat/woowa/woowachat/chat/domain/ChatRepositoryTest.java
@@ -6,7 +6,7 @@ import static chat.woowa.woowachat.chat.domain.Question.question;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.jupiter.api.Assertions.assertAll;
 
-import chat.woowa.woowachat.chat.fixture.Chat2Fixture;
+import chat.woowa.woowachat.chat.fixture.ChatFixture;
 import chat.woowa.woowachat.common.annotation.JpaRepositoryTest;
 import jakarta.persistence.EntityManager;
 import org.junit.jupiter.api.DisplayName;
@@ -30,7 +30,7 @@ class ChatRepositoryTest {
     @Test
     void 채팅과_메세지를_저장한다() {
         // given
-        final Chat chat = Chat2Fixture.chat(
+        final Chat chat = ChatFixture.chat(
                 new QuestionAndAnswer(
                         question("안녕"),
                         answer("응 안녕"),
@@ -54,7 +54,7 @@ class ChatRepositoryTest {
     @Test
     void 채팅에_메세지를_추가할_수_있다() {
         // given
-        final Chat chat = Chat2Fixture.chat(
+        final Chat chat = ChatFixture.chat(
                 new QuestionAndAnswer(
                         question("안녕"),
                         answer("응 안녕"),

--- a/src/test/java/chat/woowa/woowachat/chat/domain/ChatTest.java
+++ b/src/test/java/chat/woowa/woowachat/chat/domain/ChatTest.java
@@ -9,7 +9,7 @@ import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.junit.jupiter.api.Assertions.assertAll;
 
 import chat.woowa.woowachat.chat.exception.TokenSizeBigException;
-import chat.woowa.woowachat.chat.fixture.Chat2Fixture;
+import chat.woowa.woowachat.chat.fixture.ChatFixture;
 import java.util.List;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.DisplayNameGeneration;
@@ -24,7 +24,7 @@ class ChatTest {
     @Test
     void QnA를_추가할_수_있다() {
         // given
-        final Chat chat = Chat2Fixture.defaultChat();
+        final Chat chat = ChatFixture.defaultChat();
 
         // when
         chat.addQuestionAndAnswer(new QuestionAndAnswer(
@@ -46,7 +46,7 @@ class ChatTest {
     @Test
     void 메세지를_추가_시_최대토큰에서_가용토큰을_뺀_길이만큼의_메세지가_들어오면_예외() {
         // given
-        final Chat chat = Chat2Fixture.chatWithModel(GPT_3_5_TURBO,
+        final Chat chat = ChatFixture.chatWithModel(GPT_3_5_TURBO,
                 new QuestionAndAnswer(
                         question("안녕"),
                         answer("응 안녕"),
@@ -82,7 +82,7 @@ class ChatTest {
                         answer("A3"),
                         1500
                 ));
-        final Chat chat = Chat2Fixture.chat(messages);
+        final Chat chat = ChatFixture.chat(messages);
 
         // when
         final List<Message> messageInterfaces = chat.messagesWithFreeToken();
@@ -116,7 +116,7 @@ class ChatTest {
                         answer("A3"),
                         GPT_3_5_TURBO.maxTokens() - FREE_TOKEN
                 ));
-        final Chat chat = Chat2Fixture.chat(messages);
+        final Chat chat = ChatFixture.chat(messages);
 
         // when
         final List<Message> result = chat.messagesWithFreeToken();

--- a/src/test/java/chat/woowa/woowachat/chat/domain/ChatTest.java
+++ b/src/test/java/chat/woowa/woowachat/chat/domain/ChatTest.java
@@ -85,7 +85,8 @@ class ChatTest {
         final Chat chat = ChatFixture.chat(messages);
 
         // when
-        final List<Message> messageInterfaces = chat.messagesWithFreeToken();
+        final List<Message> messageInterfaces = chat.qnaWithFreeToken()
+                .messagesWithSettingMessage(chat.settingMessage());
 
         // then
         assertThat(messageInterfaces).extracting(Message::content)
@@ -119,7 +120,8 @@ class ChatTest {
         final Chat chat = ChatFixture.chat(messages);
 
         // when
-        final List<Message> result = chat.messagesWithFreeToken();
+        final List<Message> result = chat.qnaWithFreeToken()
+                .messagesWithSettingMessage(chat.settingMessage());
 
         // then
         assertThat(result).extracting(Message::content)

--- a/src/test/java/chat/woowa/woowachat/chat/domain/GptClientTest.java
+++ b/src/test/java/chat/woowa/woowachat/chat/domain/GptClientTest.java
@@ -147,7 +147,7 @@ class GptClientTest {
                         1000
                 )
         );
-        final Chat chat = Chat2Fixture.chatWithModel(GPT_3_5_TURBO, messages);
+        final Chat chat = ChatFixture.chatWithModel(GPT_3_5_TURBO, messages);
 
         // when
         final ChatCompletionRequest from = ChatCompletionRequest.of(chat, question("질문"));

--- a/src/test/java/chat/woowa/woowachat/chat/domain/GptClientTest.java
+++ b/src/test/java/chat/woowa/woowachat/chat/domain/GptClientTest.java
@@ -8,8 +8,6 @@ import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.BDDMockito.given;
 import static org.mockito.Mockito.mock;
-import static org.mockito.Mockito.times;
-import static org.mockito.Mockito.verify;
 
 import chat.woowa.woowachat.chat.domain.GptClient.ChatCompletionRequest;
 import chat.woowa.woowachat.chat.domain.GptClient.ChatCompletionRequest.MessageRequest;
@@ -17,7 +15,7 @@ import chat.woowa.woowachat.chat.domain.GptClient.ChatCompletionResponse;
 import chat.woowa.woowachat.chat.domain.GptClient.ChatCompletionResponse.ChoiceResponse;
 import chat.woowa.woowachat.chat.domain.GptClient.ChatCompletionResponse.MessageResponse;
 import chat.woowa.woowachat.chat.domain.GptClient.ChatCompletionResponse.UsageResponse;
-import chat.woowa.woowachat.chat.fixture.Chat2Fixture;
+import chat.woowa.woowachat.chat.fixture.ChatFixture;
 import java.util.List;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.DisplayNameGeneration;
@@ -40,62 +38,46 @@ class GptClientTest {
     private final RestTemplate restTemplate = mock(RestTemplate.class);
     private final GptClient client = new GptClient(restTemplate, apiKeySettingHeader, "");
 
-    @Test
-    void Chat_의_messagesWithFreeToken_을_호출해야_한다() {
-        // given
-        final ChatCompletionResponse response = new ChatCompletionResponse("", ",", "",
-                List.of(new ChoiceResponse(1L,
-                        new MessageResponse("assistant", "답변"),
-                        "stop")),
-                new UsageResponse(1, 2, 3));
-
-        given(restTemplate.postForEntity(any(String.class), any(), any())).willReturn(
-                ResponseEntity.status(200).body(response));
-        final Chat chat = mock(Chat.class);
-
-        // when
-        client.ask(chat, Question.question("질문"));
-
-        // then
-        verify(chat, times(1))
-                .messagesWithFreeToken();
-    }
-
 
     @Test
     void 받아온_응답을_바탕으로_QnA의_토큰_수를_계산하여_반환한다() {
         // given
-        final Chat chat = mock(Chat.class);
+        final List<QuestionAndAnswer> messages = List.of(
+                new QuestionAndAnswer(
+                        question("Q1"),
+                        answer("A1"),
+                        1000
+                )
+        );
+        final Chat chat = ChatFixture.chat(messages);
         final ChatCompletionResponse response = new ChatCompletionResponse("", ",", "",
                 List.of(new ChoiceResponse(1L,
                         new MessageResponse("assistant", "답변"),
                         "stop")),
-                new UsageResponse(2500, 500, 3000));
+                new UsageResponse(1500, 500, 2000));
 
         given(restTemplate.postForEntity(any(String.class), any(), any())).willReturn(
                 ResponseEntity.status(200).body(response));
-
-        given(chat.totalToken()).willReturn(2000);
 
         // when
         final QuestionAndAnswer qna = client.ask(chat, question("질문"));
 
         // then
-        // 기존 채팅 [2000], API 결과 전체 토큰 [3000] -> [3000] - [2000] = 1000
+        // 기존 채팅 [1000], API 결과 전체 토큰 [2000] -> [2000] - [1000] = 1000
         assertThat(qna.token()).isEqualTo(1000);
     }
 
-    /**
-     * Caused by: org.springframework.web.client.HttpClientErrorException$BadRequest: 400 Bad Request: "{<EOL> "error":
-     * {<EOL> "message": "This model's maximum context length is 4097 tokens. However, your messages resulted in 8436
-     * tokens. Please reduce the length of the messages.",
-     * <EOL> "type": "invalid_request_error",<EOL>
-     * "param": "messages",<EOL> "code": "context_length_exceeded"<EOL> }<EOL>}<EOL>”
-     */
     @Test
     void 질문의_토큰이_허용치를_넘어_GPT_API_에서_오류가_반환된다면_이를_처리한다() {
         // given
-        final Chat chat = mock(Chat.class);
+        final List<QuestionAndAnswer> messages = List.of(
+                new QuestionAndAnswer(
+                        question("Q1"),
+                        answer("A1"),
+                        1000
+                )
+        );
+        final Chat chat = ChatFixture.chat(messages);
         given(restTemplate.postForEntity(any(String.class), any(), any()))
                 .willThrow(new HttpClientErrorException(HttpStatus.BAD_REQUEST, OVER_MAX_TOKEN_CODE));
 
@@ -107,7 +89,14 @@ class GptClientTest {
 
     @Test
     void GPT_API_에_문제가_있는_경우_예외처리() {
-        final Chat chat = mock(Chat.class);
+        final List<QuestionAndAnswer> messages = List.of(
+                new QuestionAndAnswer(  // 제외
+                        question("Q1"),
+                        answer("A1"),
+                        100
+                )
+        );
+        final Chat chat = ChatFixture.chat(messages);
         given(restTemplate.postForEntity(any(String.class), any(), any()))
                 .willThrow(new RestClientException("some problem"));
 

--- a/src/test/java/chat/woowa/woowachat/chat/domain/QuestionAndAnswersTest.java
+++ b/src/test/java/chat/woowa/woowachat/chat/domain/QuestionAndAnswersTest.java
@@ -4,7 +4,6 @@ import static chat.woowa.woowachat.chat.domain.Answer.answer;
 import static chat.woowa.woowachat.chat.domain.Question.question;
 import static org.assertj.core.api.Assertions.assertThat;
 
-import java.util.List;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.DisplayNameGeneration;
 import org.junit.jupiter.api.DisplayNameGenerator;
@@ -55,10 +54,10 @@ class QuestionAndAnswersTest {
         );
 
         // when
-        final List<QuestionAndAnswer> result = questionAndAnswers.lessOrEqualThan(token);
+        final QuestionAndAnswers result = questionAndAnswers.lessOrEqualThan(token);
 
         // then
-        assertThat(result)
+        assertThat(result.questionAndAnswers())
                 .extracting(QuestionAndAnswer::question)
                 .containsExactly(question("질문2"), question("질문3"));
     }
@@ -77,10 +76,10 @@ class QuestionAndAnswersTest {
         );
 
         // when
-        final List<QuestionAndAnswer> result = questionAndAnswers.lessOrEqualThan(token);
+        final QuestionAndAnswers result = questionAndAnswers.lessOrEqualThan(token);
 
         // then
-        assertThat(result)
+        assertThat(result.questionAndAnswers())
                 .extracting(QuestionAndAnswer::question)
                 .containsExactly(question("질문1"));
     }

--- a/src/test/java/chat/woowa/woowachat/chat/fixture/ChatFixture.java
+++ b/src/test/java/chat/woowa/woowachat/chat/fixture/ChatFixture.java
@@ -9,7 +9,7 @@ import chat.woowa.woowachat.chat.domain.QuestionAndAnswer;
 import java.util.Arrays;
 import java.util.List;
 
-public class Chat2Fixture {
+public class ChatFixture {
 
     public static Chat defaultChat() {
         return new Chat(GPT_3_5_TURBO,

--- a/src/test/java/chat/woowa/woowachat/integration/GptClientIntTest.java
+++ b/src/test/java/chat/woowa/woowachat/integration/GptClientIntTest.java
@@ -7,7 +7,7 @@ import chat.woowa.woowachat.chat.domain.Chat;
 import chat.woowa.woowachat.chat.domain.GptClient;
 import chat.woowa.woowachat.chat.domain.Question;
 import chat.woowa.woowachat.chat.domain.QuestionAndAnswer;
-import chat.woowa.woowachat.chat.fixture.Chat2Fixture;
+import chat.woowa.woowachat.chat.fixture.ChatFixture;
 import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.DisplayNameGeneration;
@@ -30,7 +30,7 @@ class GptClientIntTest {
     void Chat_Completion_API_에_질문을_보내고_답변을_받아온다() {
         // given
         final Chat chat =
-                Chat2Fixture.chat(
+                ChatFixture.chat(
                         new QuestionAndAnswer(
                                 Question.question("안녕?"),
                                 Answer.answer("네. 안녕하세요"),


### PR DESCRIPTION
@Transactional 어노테이션을 self invocation 문제 때문에 범위를 조절하는데 사용하기 어려워서,
TransactionTemplate을 사용해서 트랜잭션 범위를 제어했어.
그 과정에서 Chat이 가진 QnA들을 초기화하기 위해 fetch join을 사용했음!

close #36